### PR TITLE
Disable dark theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,20 +13,9 @@ theme:
   logo: assets/hat_labs_logo.svg
   favicon: assets/hat_labs_logo.svg
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: custom
-      accent: custom
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: custom
-      accent: custom
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+    scheme: default
+    primary: custom
+    accent: custom
   font:
     text: IBM Plex Sans
     code: IBM Plex Mono


### PR DESCRIPTION
## Summary
- Remove dark mode palette to fix rendering issues with transparent vector graphics on dark backgrounds

## Test plan
- [ ] Verify site renders in light mode only
- [ ] No dark/light toggle visible in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)