### PR TITLE
Add PDF export to the SH-RPi docs

### DIFF
--- a/docs/add-ons/can-hat/index.md
+++ b/docs/add-ons/can-hat/index.md
@@ -2,6 +2,8 @@
 title: Waveshare 2-Channel Isolated CAN HAT
 ---
 
+# CAN HAT
+
 The Waveshare 2-Channel Isolated CAN HAT provides two isolated CAN interfaces for the Raspberry Pi. The CAN HAT is based on the MCP2515 CAN controller and SI65HVD230/SN65HVD230 CAN transceivers. The HAT can be used to implement a single compliant NMEA 2000 interface or two other CAN interfaces. When used as an NMEA 2000 interface, the second channel should be unused due to NMEA 2000 isolation requirements.
 
 The HAT has an integrated isolated DC/DC transformer and doesn't require external power input.

--- a/docs/add-ons/cm4/index.md
+++ b/docs/add-ons/cm4/index.md
@@ -2,6 +2,8 @@
 title: Compute Module 4
 ---
 
+# Compute Module 4
+
 The [Compute Module 4](https://www.raspberrypi.org/products/compute-module-4/) is a small form factor computer module that plugs into a carrier board. Providing CPU performance identical to the Raspberry Pi 4B,tThe CM4 is a powerful, flexible, and low-cost solution for embedded applications. When building embedded computers, the CM4 has several advantages over the Raspberry Pi 4B:
 
 - Built-in eMMC flash memory: The CM4 boards have, depending on the model, up to 32 GB of eMMC flash memory. This memory is both more reliable and faster than the SD card used in the Raspberry Pi 4B.

--- a/docs/add-ons/gnss-hat/index.md
+++ b/docs/add-ons/gnss-hat/index.md
@@ -2,6 +2,8 @@
 title: Waveshare MAX-M8Q GNSS HAT
 ---
 
+# GNSS HAT
+
 The Waveshare MAX-M8Q GNSS HAT provides a high-quality GNSS receiver for the Raspberry Pi, based on the U-blox MAX-M8Q module. MAX-M8Q features a multi-constellation GNSS receiver with a high sensitivity of -167 dBm. It supports GPS, GLONASS, BeiDou and Galileo and can receive concurrently from three of these. Additionally, several augmentation schemes such as SBAS, QZSS, IMES and D-GPS are supported.
 
 This page describes the installation and configuration of the GNSS HAT when used together with the Sailor Hat for Raspberry Pi. For further details on the GNSS HAT, see the [Waveshare wiki page](https://www.waveshare.com/wiki/MAX-M8Q_GNSS_HAT).

--- a/docs/add-ons/rs485-hat/index.md
+++ b/docs/add-ons/rs485-hat/index.md
@@ -2,6 +2,8 @@
 title: Waveshare 2-Channel Isolated RS485 HAT
 ---
 
+# RS485 HAT
+
 The Waveshare 2-Channel Isolated RS485 HAT provides two isolated RS-485 interfaces for the Raspberry Pi. It can be used to implement a bidirectional NMEA 0183 interface or two generic bidirectional RS-485 interfaces. When used as an NMEA 0183 interface, one channel is used for receiving and the other for transmitting data.
 
 The HAT has an integrated isolated DC/DC transformer and doesn't require external power input.

--- a/docs/errata/index.md
+++ b/docs/errata/index.md
@@ -2,6 +2,8 @@
 title: Errata
 ---
 
+# Errata
+
 This page lists all known hardware bugs for different SH-RPi revisions.
 
 ## Version 2.0.0

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -2,6 +2,8 @@
 title: Frequently Asked Questions
 ---
 
+# FAQ
+
 ## Can I power the Raspberry Pi using the standard USB-C connector while the SH-RPi is connected?
 
 The answer is no. Or at least, this should be avoided. Nothing will happen if the SH-RPi is powered and the supercaps are charged above 5V. However, if the supercaps are discharged, they will be back-powered through the 5V bus. In practice, this will likely overpower the USB power supply and cause it to shut down without any permanent damage. However, this is not a controlled situation and damage is possible to the power supply, the Raspberry Pi, or the SH-RPi itself.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,6 +2,8 @@
 title: Getting Started
 ---
 
+# Getting Started
+
 ## Hardware Assembly
 
 SH-RPi is delivered fully assembled. The hardware installation steps are:

--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -2,6 +2,8 @@
 title: Hardware Description
 ---
 
+# Hardware Description
+
 ## Tour Around the Board
 
 Different functional blocks of the Sailor Hat for Raspberry Pi are described below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 title: Introduction
 ---
 
+# Introduction
+
 !!! info
     Looking for the old Sailor Hat for Raspberry Pi v1.0.0 documentation? It's available at [docs.hatlabs.fi/sh-rpi-v1](https://docs.hatlabs.fi/sh-rpi-v1/).
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,12 @@
   <a href="https://github.com/hatlabs/discussions/discussions">Discussion</a>
 </nav>
 {% endblock %}
+
+{% block content %}
+{% if page.url_to_print_page %}
+  <a href="{{ page.url_to_print_page }}" title="Print or save as PDF" class="md-content__button md-icon">
+    {% include ".icons/material/printer.svg" %}
+  </a>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/docs/revisions/index.md
+++ b/docs/revisions/index.md
@@ -2,6 +2,8 @@
 title: Hardware Revisions
 ---
 
+# Hardware Revisions
+
 ## Introduction
 
 This page documents different board revisions and provides links to the schematics. Full design file history is available at the [SH-RPi-hardware GitHub repository](https://github.com/hatlabs/SH-RPi-hardware).

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -2,6 +2,8 @@
 title: Software
 ---
 
+# Software
+
 ## Introduction
 
 The Sailor Hat for Raspberry Pi requires additional software on the Raspberry Pi Operating System to fully utilize the device functionality. An installation script is provided to automatically install all required software on a fresh Raspberry Pi OS installation. Use of the installation script is described in the [Getting Started Section](../getting-started/index.md). You will only need to follow the manual installation instructions if you prefer not to have automated scripts modify your system configuration or if you have to troubleshoot your installation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,11 @@ theme:
 
 plugins:
   - search
+  - print-site:
+      add_cover_page: true
+      add_print_site_banner: true
+      add_to_navigation: false
+      print_page_title: "Sailor Hat for Raspberry Pi"
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,8 @@ name = "sh-rpi-docs"
 version = "0.1.0"
 description = "Sailor Hat for Raspberry Pi documentation"
 requires-python = ">=3.11"
-dependencies = ["mkdocs-material>=9.5", "click<8.3"]
+dependencies = [
+    "mkdocs-material>=9.5",
+    "click<8.3",
+    "mkdocs-print-site-plugin>=2.8",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -339,6 +339,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-print-site-plugin"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs-material" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/18/5c71f48b83191fb30cc58617fea20f56647eaa6cafd06a7fb34c738c5acb/mkdocs_print_site_plugin-2.8.tar.gz", hash = "sha256:ab1c89cdb468352975e3bb3bb0ef25dcc2bb88931b03f173206dc95ab02f843f", size = 231688, upload-time = "2025-08-03T14:15:07.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3e/7513f2f37c563da65d1b91781e047f4a1c0ceac8206d4f6042428428e4ad/mkdocs_print_site_plugin-2.8-py3-none-any.whl", hash = "sha256:838bd0a9b7141c11c0f1fdaa51ffe70c35740bec1f07c0806f8018e92f93f9da", size = 21477, upload-time = "2025-08-03T14:15:06.301Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,12 +509,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "click" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-print-site-plugin" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = "<8.3" },
     { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-print-site-plugin", specifier = ">=2.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Readers want an offline/printable copy of the guide. This adds a one-click path from any page to a PDF.

## How

Uses [mkdocs-print-site-plugin](https://timvink.github.io/mkdocs-print-site-plugin/): a printer icon on every page (top-right, beside the edit pencil) links to a combined `/print_page/` that aggregates the whole guide with a cover page and an auto-numbered TOC. A banner on that page instructs the reader to export via **File > Print > Save as PDF** — the browser renders the PDF, so diagrams and CSS come out exactly as on screen.

Same change as the HALPI2 docs (hatlabs/halpi2#24). Adds **no CI dependencies** — `uv sync` picks up the new package.

## Two commits

1. **`docs: add leading H1 …`** — several section landing pages took their title from front matter / nav and started with prose or an `h2`. The print plugin needs a leading `# H1` to title each section in the combined page (and `--strict` treats the missing-H1 warning as fatal). Added an explicit top-level heading, using each page's existing title, so every page has one leading H1 — consistent with the other product docs.
2. **`feat(docs): add PDF export …`** — the plugin wiring itself.

## Verified

- `uv run mkdocs build --strict` → exit 0, zero warnings
- Printer button renders on every page; print page produces cover + banner + full aggregated guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
