### PR TITLE
fix(theme): show every language in the selector without scrolling

### DIFF
--- a/.claude/skills/translate-page/SKILL.md
+++ b/.claude/skills/translate-page/SKILL.md
@@ -88,6 +88,33 @@ one failure the status check cannot detect, and this skill is where the
 discipline lives. If you touched only the target language (fixing wording,
 fixing a typo), the English source did not change: leave the stamp alone.
 
+## Adding a language to the site
+
+When a locale is added to `mkdocs.yml`, check the language selector too. The
+Material theme caps the open menu at `10rem`, which fits five entries at the
+site's font size; the sixth language onward scrolls out of sight behind a
+scrollbar that gives no hint anything is below it.
+
+`docs/stylesheets/extra.css` should carry:
+
+```css
+.md-select:focus-within .md-select__inner,
+.md-select:hover .md-select__inner {
+  max-height: min(24rem, 75vh);
+}
+```
+
+24rem clears thirteen entries; the viewport term keeps the menu on screen on a
+short display. The same block is in the HALPI2 and HALMET repositories — keep
+the three identical, and add it to any further site that gains a second
+language.
+
+Verify by measuring rather than by eye: open the site, read the rule's
+`max-height` off the stylesheet, and compare it against the list's natural
+height with `.md-select__list.getBoundingClientRect()`. Hovering for a
+screenshot is unreliable — the menu often has not opened by the time the frame
+is captured.
+
 ## Verifying
 
 All four, every time:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -51,3 +51,11 @@
   color: var(--md-default-fg-color--light);
   margin-top: 1.2rem;
 }
+
+/* The theme caps the open language selector at 10rem, which fits five of the
+   ten languages and silently scrolls the rest. 24rem clears thirteen; the
+   viewport term keeps the menu on screen on a short display. */
+.md-select:focus-within .md-select__inner,
+.md-select:hover .md-select__inner {
+  max-height: min(24rem, 75vh);
+}


### PR DESCRIPTION
The language selector shows five of the ten languages. The rest are reachable only by scrolling inside the dropdown, which gives no visual hint there is anything below.

Same fix already merged in hatlabs/halpi2#38 and hatlabs/halmet#22; this brings the third site into line.

## Cause and fix

Material caps the open menu at `max-height: 10rem`. At this site's font size that resolves to 200px, and each entry is 36px — five rows. The list needs 360px for ten languages.

```css
.md-select:focus-within .md-select__inner,
.md-select:hover .md-select__inner {
  max-height: min(24rem, 75vh);
}
```

24rem resolves to 480px, clearing thirteen entries, so adding a language later does not immediately reintroduce the problem. The `75vh` term keeps the menu on screen on a short display.

## Measured, not estimated

Read from the rendered page: entry height 36px, list needs 360px, old cap 200px (five visible), new cap 480px (all ten visible, room for thirteen). Verified by reading the rule off the stylesheet and comparing it to `.md-select__list.getBoundingClientRect()` rather than by hovering for a screenshot, which is unreliable — the menu often has not opened by the time the frame is captured.

## Also: this should stop needing to be asked

Helmi has now requested this three times, once per site. The `translate-page` skill in all three repositories gains a section, **Adding a language to the site**, carrying the rule and the instruction to keep the three copies identical — so the next site to gain a second language gets it as part of the same work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
